### PR TITLE
fixed parameter deprecation in training/generation script of SpatialAttentionGAN

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -92,5 +92,5 @@ if __name__ == '__main__':
                     nrow=3,
                     padding=0,
                     normalize=True,
-                    value_range=(-1.,1.)
+                    range=(-1.,1.)
                 )

--- a/generate.py
+++ b/generate.py
@@ -92,5 +92,5 @@ if __name__ == '__main__':
                     nrow=3,
                     padding=0,
                     normalize=True,
-                    range=(-1.,1.)
+                    value_range=(-1.,1.)
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.14.0
 scikit-image>=0.14.2
 tqdm
-torch
-torchvision
+torch==1.11.0
+torchvision==0.12.0
 torchsummary
 tensorboardX

--- a/train.py
+++ b/train.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
         break
     del test_dset
     del test_data
-    vutils.save_image(fixed_reals, join(sample_path, '{:07d}_real.jpg'.format(0)), nrow=8, padding=0, normalize=True, range=(-1., 1.))
+    vutils.save_image(fixed_reals, join(sample_path, '{:07d}_real.jpg'.format(0)), nrow=8, padding=0, normalize=True, value_range=(-1., 1.))
     
     # Models
     G = Generator()
@@ -225,7 +225,7 @@ if __name__ == '__main__':
                 G.eval()
                 with torch.no_grad():
                     samples, masks = G(fixed_reals, fixed_target_labels)
-                    vutils.save_image(samples, join(sample_path, '{:07d}_fake.jpg'.format(cur_nimg)), nrow=8, padding=0, normalize=True, range=(-1., 1.))
+                    vutils.save_image(samples, join(sample_path, '{:07d}_fake.jpg'.format(cur_nimg)), nrow=8, padding=0, normalize=True, value_range=(-1., 1.))
                     vutils.save_image(masks.repeat(1, 3, 1, 1), join(sample_path, '{:07d}_mask.jpg'.format(cur_nimg)), nrow=8, padding=0)
             
             # Model checkpoints

--- a/train.py
+++ b/train.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
         break
     del test_dset
     del test_data
-    vutils.save_image(fixed_reals, join(sample_path, '{:07d}_real.jpg'.format(0)), nrow=8, padding=0, normalize=True, value_range=(-1., 1.))
+    vutils.save_image(fixed_reals, join(sample_path, '{:07d}_real.jpg'.format(0)), nrow=8, padding=0, normalize=True, range=(-1., 1.))
     
     # Models
     G = Generator()
@@ -225,7 +225,7 @@ if __name__ == '__main__':
                 G.eval()
                 with torch.no_grad():
                     samples, masks = G(fixed_reals, fixed_target_labels)
-                    vutils.save_image(samples, join(sample_path, '{:07d}_fake.jpg'.format(cur_nimg)), nrow=8, padding=0, normalize=True, value_range=(-1., 1.))
+                    vutils.save_image(samples, join(sample_path, '{:07d}_fake.jpg'.format(cur_nimg)), nrow=8, padding=0, normalize=True, range=(-1., 1.))
                     vutils.save_image(masks.repeat(1, 3, 1, 1), join(sample_path, '{:07d}_mask.jpg'.format(cur_nimg)), nrow=8, padding=0)
             
             # Model checkpoints


### PR DESCRIPTION
since installing dependencies via `requirements.txt`, the version of `torchvision` is not specified, so that it will install the latest version of torchvision. This result by causing an error when we execute the 'train.py' and `generate.py` to save a generated image from Spatial Attention GAN as in #6 due to some parameters in `vutils` that already deprecated. To solve this, i will not touch the dependencies in your requirements.txt file, but i decide to fix the deprecated parameters of `vutils` to make it compatible with the current version of the dependencies instead.

ps. it may better if we just directly fix the dependencies in requirements.txt file, however, directly fix it by an owner would be the best option for sure.